### PR TITLE
Add backend health test with Jest and Supertest

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ docker compose logs backend
 docker compose logs frontend
 ```
 
+## Backend Tests
+
+To run the backend test suite:
+
+```bash
+cd backend
+npm test
+```
+
 ## 🎮 Usage Guide
 
 ### Adding Transactions

--- a/backend/index.js
+++ b/backend/index.js
@@ -457,7 +457,11 @@ app.get('/categories', async (req, res) => {
 });
 
 const PORT = process.env.PORT || 3001;
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 DFinance API server running on port ${PORT}`);
-  console.log(`🏁 Environment: ${process.env.NODE_ENV || 'development'}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`🚀 DFinance API server running on port ${PORT}`);
+    console.log(`🏁 Environment: ${process.env.NODE_ENV || 'development'}`);
+  });
+}
+
+module.exports = app;

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": ["finance", "tracker", "api", "postgres"],
   "author": "DFinance Team",
@@ -22,6 +22,8 @@
     "helmet": "^7.1.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('Health endpoint', () => {
+  it('should return 200 and {status:"OK"}', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: 'OK' });
+  });
+});


### PR DESCRIPTION
## Summary
- configure backend for Jest and Supertest
- add health endpoint test
- document backend test execution

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a32560fc8320ab753d782273e812